### PR TITLE
Use /usr/bin/env to specify the python interpreter

### DIFF
--- a/blast_summary.py
+++ b/blast_summary.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This script is for summarizing BLAST XML results into a table
 
 # Edits
@@ -56,7 +56,7 @@ with open(parsedOpts.input) as fBlast:
          break
       else:
          pass
-       
+
 #For output file
 if parsedOpts.output:
    if (parsedOpts.output).endswith(".sum"):


### PR DESCRIPTION
Instead of hard-coding it to /usr/bin/python
